### PR TITLE
Attempt to download icon if icon_hash exists in pkginfo

### DIFF
--- a/code/client/munkilib/updatecheck/download.py
+++ b/code/client/munkilib/updatecheck/download.py
@@ -269,10 +269,10 @@ def download_icons(item_list):
                 return
         if server_icon_hash != local_hash:
             # hashes don't match, so download the icon
-            if icon_hashes and icon_name not in icon_hashes:
-                # if we have a list of icon hashes, and the icon name is not
-                # in that list, then there's no point in attempting to
-                # download this icon
+            if not server_icon_hash:
+                # The icon hash must be in the ICON_HASHES_PLIST_NAME file 
+                # or the pkginfo itself. If it is not in either of these,
+                # then there's no point in attempting to download this icon.
                 continue
             item_name = item.get('display_name') or item['name']
             icon_url = icon_base_url + quote(icon_name.encode('UTF-8'))


### PR DESCRIPTION
Munki minimizes unnecessary icon downloads by assuming if an icon_name does not exist in the ICON_HASHES_PLIST_NAME file (and the repo has that file), that the icon must not exist. 

Munki provides the ability to specify icons_name and icon_hash in the pkginfo itself for special cases where an icon is in a non-standard location and will even overwrite values in ICON_HASHES_PLIST_NAME if these exist. The problem is that if an icon_name is missing from the ICON_HASHES_PLIST_NAME, munki does not attempt to use the information from the pkginfo due to the previously mentioned optimization.

To fix this while still minimizing the number of invalid icon requests, we use the exists of an icon hash (either from the ICON_HASHES_PLIST_NAME file or the pkginfo) as the guard.


[CLA_MUNKI_DTHEYER.pdf](https://github.com/user-attachments/files/21874398/CLA_MUNKI_DTHEYER.pdf)